### PR TITLE
Fixed bug in setting pu and pl

### DIFF
--- a/juliet/fit.py
+++ b/juliet/fit.py
@@ -1885,7 +1885,7 @@ class fit(object):
                             pnum][i] = Y - out['posterior_samples']['P_' +
                                                                     pnum][i] * X
             if self.data.t_lc is not None:
-                if True in self.data.lc_options['efficient_bp']:
+                if True in self.data.lc_options['efficient_bp'].values():
                     out['pu'] = self.pu
                     out['pl'] = self.pl
             if self.data.t_rv is not None:


### PR DESCRIPTION
I discovered this bug when I was trying to fit 3 planets with only the second planet transiting. 
`lc_options['efficient_bp']` is a dict, and we want to look at its values rather than its keys.