### PR TITLE
Matern+SHO kernel implemented

### DIFF
--- a/juliet/fit.py
+++ b/juliet/fit.py
@@ -3977,6 +3977,16 @@ class gaussian_process(object):
                 self.parameter_vector[8] = np.log(
                     parameter_values['sigma_w_' + self.instrument] *
                     self.sigma_factor)
+        
+        # For Matern+SHO kernel
+        elif self.kernel_name == 'CeleriteMaternSHOKernel':
+            self.parameter_vector[0] = np.log(parameter_values['GP_sigma_'+self.input_instrument[0]])
+            self.parameter_vector[1] = np.log(parameter_values['GP_rho_'+self.input_instrument[1]])
+            self.parameter_vector[2] = np.log(parameter_values['GP_S0_'+self.input_instrument[2]])
+            self.parameter_vector[3] = np.log(parameter_values['GP_Q_'+self.input_instrument[3]])
+            self.parameter_vector[4] = np.log(parameter_values['GP_omega0_'+self.input_instrument[4]])
+            if not self.global_GP:
+                self.parameter_vector[5] = np.log(parameter_values['sigma_w_'+self.instrument]*self.sigma_factor)
                 
         self.GP.set_parameter_vector(self.parameter_vector)
 
@@ -4077,6 +4087,8 @@ class gaussian_process(object):
         self.all_kernel_variables['CeleriteDoubleSHOKernel'] = [
             'sigma', 'Q0', 'period', 'f', 'dQ'
         ]
+        # For Matern+SHO kernel
+        self.all_kernel_variables['CeleriteMaternSHOKernel'] = ['sigma', 'rho', 'S0', 'Q', 'omega0']
 
         # Find kernel name (and save it to self.kernel_name):
         self.kernel_name = self.get_kernel_name(data.priors)
@@ -4211,6 +4223,21 @@ class gaussian_process(object):
             else:
                 self.kernel = double_sho_kernel + kernel_jitter
             # We are using celerite:
+            self.use_celerite = True
+        ## For Matern+SHO kernel
+        elif self.kernel_name == 'CeleriteMaternSHOKernel':
+            # Matern kernel:
+            matern_kernel = terms.Matern32Term(log_sigma=np.log(10.), log_rho=np.log(10.), eps = matern_eps)
+            # SHO kernel:
+            sho_kernel = terms.SHOTerm(log_S0=np.log(10.), log_Q=np.log(10.),log_omega0=np.log(10.))
+            # Jitter term:
+            kernel_jitter = terms.JitterTerm(np.log(100*1e-6))
+            # Wrap GP kernel and object:
+            if self.instrument in ['rv','lc']:
+                self.kernel = matern_kernel + sho_kernel
+            else:
+                self.kernel = matern_kernel + sho_kernel + kernel_jitter
+            # And we are using celerite
             self.use_celerite = True
         # Check if use_celerite is True; if True, check that the regressor is ordered. If not, don't do the self.init_GP():
         if self.use_celerite:


### PR DESCRIPTION
This pull request adds a new GP kernel: summation of Matern-3/2 and SHO kernel from `celerite`.
As usual, the new kernel can be called by providing specific priors: GP_sigma_instrument, GP_rho_instrument, GP_S0_instrument, GP_Q_instrument, GP_omega0_instrument.
--Jayshil