### PR TITLE
Fixing a bug in `evaluate_model` function in `catwoman` model

### DIFF
--- a/juliet/fit.py
+++ b/juliet/fit.py
@@ -2306,20 +2306,26 @@ class model(object):
 
             nresampling = self.dictionary[instrument].get('nresampling')
             etresampling = self.dictionary[instrument].get('exptimeresampling')
-        
-            if self.dictionary[instrument]['TransitFit']:
-            
-                self.model[instrument]['params'], [self.model[instrument]['m'],_] = init_batman(self.times[instrument], self.dictionary[instrument]['ldlaw'],
-                                                                                                nresampling=nresampling, etresampling=etresampling)
-            elif self.dictionary[instrument]['EclipseFit']:
-              
-                self.model[instrument]['params'], [_,self.model[instrument]['m']] = init_batman(self.times[instrument], self.dictionary[instrument]['ldlaw'],
-                                                                                                nresampling=nresampling, etresampling=etresampling)
+
+            if not self.dictionary[instrument]['TransitFitCatwoman']:
+
+                if self.dictionary[instrument]['TransitFit']:
                 
-            elif self.dictionary[instrument]['TranEclFit']:
-              
-                self.model[instrument]['params'], self.model[instrument]['m'] = init_batman(self.times[instrument], self.dictionary[instrument]['ldlaw'],
+                    self.model[instrument]['params'], [self.model[instrument]['m'],_] = init_batman(self.times[instrument], self.dictionary[instrument]['ldlaw'],
+                                                                                                    nresampling=nresampling, etresampling=etresampling)
+                elif self.dictionary[instrument]['EclipseFit']:
+                
+                    self.model[instrument]['params'], [_,self.model[instrument]['m']] = init_batman(self.times[instrument], self.dictionary[instrument]['ldlaw'],
+                                                                                                    nresampling=nresampling, etresampling=etresampling)
+                    
+                elif self.dictionary[instrument]['TranEclFit']:
+                
+                    self.model[instrument]['params'], self.model[instrument]['m'] = init_batman(self.times[instrument], self.dictionary[instrument]['ldlaw'],
+                                                                                                    nresampling=nresampling, etresampling=etresampling)
+            else:
+                self.model[instrument]['params'], self.model[instrument]['m'] = init_catwoman(self.times[instrument], self.dictionary[instrument]['ldlaw'],
                                                                                                 nresampling=nresampling, etresampling=etresampling)
+
 
         # Save the original inames in the case of non-global models, and set self.inames to the input model. This is because if the model
         # is not global, in general we don't care about generating the models for the other instruments (and in the lightcurve and RV evaluation part,

--- a/juliet/utils.py
+++ b/juliet/utils.py
@@ -55,7 +55,7 @@ def init_catwoman(t, ld_law, nresampling = None, etresampling = None):
     This function initializes the catwoman code.
     """
 
-    params = batman.TransitParams()
+    params = catwoman.TransitParams()
     params.t0 = 0.
     params.per = 1.
     params.rp = 0.1


### PR DESCRIPTION
When doing `results.lc.evaluate` (where `results` is a `juliet.fit` object) with `catwoman` model, it was producing incorrect results. This was happening because `catwoman` model was not initialised in `evaluate_model` function in `model` class. This PR fixes this bug by adding a statement in the function which initialise `catwoman` model.
--Jayshil