### PR TITLE
Bug fix while using different params for different instruments for `fp`, `p` and `p1`

### DIFF
--- a/juliet/fit.py
+++ b/juliet/fit.py
@@ -3697,65 +3697,41 @@ class model(object):
                                 self.mflux_iname[instrument] = vec[1]
 
                     if pname[0:2] == 'fp':
-
                         # Note that eclipse and transit depths can be a planetary and instrumental parameter
                         vec = pname.split('_')
-
                         if len(vec) > 3:
-
                             if instrument in vec:
-
                                 self.fp_iname[vec[1]][instrument] = '_' + '_'.join(vec[2:])
-
                         else:
-
-                            if len(vec) == 3:
-
-                                self.fp_iname[vec[1]][instrument] = '_' + vec[2]
-
-                            else:
-
-                                self.fp_iname[vec[1]][instrument] = ''
+                            if instrument in vec:
+                                if len(vec) == 3:
+                                    self.fp_iname[vec[1]][instrument] = '_' + vec[2]
+                                else:
+                                    self.fp_iname[vec[1]][instrument] = ''
 
                     if pname[0:2] == 'p_':
-
                         vec = pname.split('_')
-
                         if len(vec) > 3:
-
                             if instrument in vec:
-
                                 self.p_iname[vec[1]][instrument] = '_' + '_'.join(vec[2:])
-
                         else:
-
-                            if len(vec) == 3:
-
-                                self.p_iname[vec[1]][instrument] = '_' + vec[2]
-
-                            else:
-
-                                self.p_iname[vec[1]][instrument] = ''
+                            if instrument in vec:
+                                if len(vec) == 3:
+                                    self.p_iname[vec[1]][instrument] = '_' + vec[2]
+                                else:
+                                    self.p_iname[vec[1]][instrument] = ''
 
                     if pname[0:2] == 'p1':
-
                         vec = pname.split('_')
-
                         if len(vec) > 3:
-
                             if instrument in vec:
-
                                 self.p1_iname[vec[1]][instrument] = '_' + '_'.join(vec[2:])
-
                         else:
-
-                            if len(vec) == 3:
-
-                                self.p1_iname[vec[1]][instrument] = '_' + vec[2]
-
-                            else:
-
-                                self.p_iname[vec[1]][instrument] = ''
+                            if instrument in vec:
+                                if len(vec) == 3:
+                                    self.p1_iname[vec[1]][instrument] = '_' + vec[2]
+                                else:
+                                    self.p_iname[vec[1]][instrument] = ''
 
             # Set the model-type to M(t):
             self.evaluate = self.evaluate_model


### PR DESCRIPTION
Hi @nespinoza,

The current version of `juliet` (`master` and `dev` branches, which I believe is the latest stable version) has a bug. While fitting for different parameters for `fp`, `p` and `p1` for different instruments, the sampling will happen only for the last instruments in the list. For example, while fitting for `fp_p1_instrument1` and `fp_p1_instrument2`, the sampling will happen only for the later parameter and the prior would return as posterior for the former.

This is because of a missing `if` statement while creating `self.fp_iname`, `self.p_iname` and `self.p1_iname` dictionaries in `__init__` function of the `model` class (see, changes below to see what I mean). Because of this missing `if` statement, those `self.fp_iname[p1][ins]` etc. dictionaries were kept updating for each `ins` in the loop and the final value of `self.fp_iname[p1][ins]` would always correspond to the last instrument in the loop. This PR fixes this issue by adding an `if` statement. Let me know if you have any questions on this.

Cheers,
Jayshil