### PR TITLE
Fix light travel time for circular orbit

### DIFF
--- a/juliet/utils.py
+++ b/juliet/utils.py
@@ -123,7 +123,7 @@ def correct_light_travel_time(times, params):
     else:
         # No need to solve Kepler's equation for circular orbits, so save
         # some computation time
-        transit_x = a*np.sin(params.inc)
+        transit_x = a*np.sin(params.inc*np.pi/180)
         old_x = transit_x*np.cos(2*np.pi*(times-params.t0)/params.per)
 
     # Get the radial distance variations of the planet


### PR DESCRIPTION
For circular orbit case, multiply `params.inc` by `np.pi/180` to convert degrees to radians in the argument of the `sin` function.

# Before Change

Code:
```
transit_x = a*np.sin(params.inc)
```

Test:
```
(juliet) before$ ./test-fix-ltt.py 
Warning: no zeus installation found. Will not be able to sample using sampler = 'zeus'.
light travel time delay for eccentric orbit: 52.10 s
light travel time delay for circular orbit: -38.05 s
```

# After Change

Code:
```
transit_x = a*np.sin(params.inc*np.pi/180)
```

Test:
```
(juliet) after$ ./test-fix-ltt.py 
Warning: no zeus installation found. Will not be able to sample using sampler = 'zeus'.
light travel time delay for eccentric orbit: 52.10 s
light travel time delay for circular orbit: 52.10 s
```

# Test Code

```
#!/usr/bin/env python

from juliet.utils import correct_light_travel_time

class Params:
    '''Handle orbit parameters as attributes.'''
    pass

params = Params()
params.per = 3.7355
params.t0 = 2460016.7264
params.a = 7.1142
params.inc = 87.1472  # degress
params.w = 84.0037    # degress
params.Rs = 1.58      # Rstar/Rsun
tsec = 2460018.60477

# Eccentric case.
params.ecc = 1e-5
earlier_time_for_model = correct_light_travel_time(tsec, params)
delay_ecc = (tsec - earlier_time_for_model[0]) * 24 * 3600
print(f'light travel time delay for eccentric orbit: {delay_ecc:.2f} s')

# Eccentric case.
params.ecc = 0
earlier_time_for_model = correct_light_travel_time(tsec, params)
delay_cir = (tsec - earlier_time_for_model[0]) * 24 * 3600
print(f'light travel time delay for circular orbit: {delay_cir:.2f} s')
```